### PR TITLE
Allow GUID function parameters to be entered by user

### DIFF
--- a/KLH Snoop/ParameterEditor.xaml.vb
+++ b/KLH Snoop/ParameterEditor.xaml.vb
@@ -130,6 +130,8 @@ Public Class ParameterValue
                 Return Integer.TryParse(ArgumentString, out)
             Case GetType(Double)
                 Return Double.TryParse(ArgumentString, out)
+            Case GetType(Guid)
+                Return Guid.TryParse(ArgumentString, out)
             Case GetType(ElementId)
                 Dim int = 0
                 If Integer.TryParse(ArgumentString, int) Then


### PR DESCRIPTION
Added a case for GUID to the function that translates user string input into the appropriate parameter type